### PR TITLE
Extract data from bundle directly

### DIFF
--- a/app/src/main/java/com/example/android/sunshine/app/gcm/MyGcmListenerService.java
+++ b/app/src/main/java/com/example/android/sunshine/app/gcm/MyGcmListenerService.java
@@ -38,7 +38,6 @@ public class MyGcmListenerService extends GcmListenerService {
 
     private static final String TAG = "MyGcmListenerService";
 
-    private static final String EXTRA_DATA = "data";
     private static final String EXTRA_WEATHER = "weather";
     private static final String EXTRA_LOCATION = "location";
 
@@ -63,17 +62,11 @@ public class MyGcmListenerService extends GcmListenerService {
             // Not a bad idea to check that the message is coming from your server.
             if ((senderId).equals(from)) {
                 // Process message and then post a notification of the received message.
-                try {
-                    JSONObject jsonObject = new JSONObject(data.getString(EXTRA_DATA));
-                    String weather = jsonObject.getString(EXTRA_WEATHER);
-                    String location = jsonObject.getString(EXTRA_LOCATION);
+                    String weather = data.getString(EXTRA_WEATHER);
+                    String location = data.getString(EXTRA_LOCATION);
                     String alert =
                             String.format(getString(R.string.gcm_weather_alert), weather, location);
                     sendNotification(alert);
-                } catch (JSONException e) {
-                    // JSON parsing failed, so we just let this message go, since GCM is not one
-                    // of our critical features.
-                }
             }
             Log.i(TAG, "Received: " + data.toString());
         }


### PR DESCRIPTION
The data could be extracted directly from the bundle instead of converting it to a JSONObject and then extracting it. Converting to JSONObject also causes a NullPointerException which could be avoided by the above changes.