### PR TITLE
Correction in naming of services

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -156,14 +156,14 @@
             android:exported="false"
             android:permission="android.permission.BIND_REMOTEVIEWS" />
         <service
-            android:name="gcm.MyGcmListenerService"
+            android:name=".gcm.MyGcmListenerService"
             android:exported="false" >
             <intent-filter>
                 <action android:name="com.google.android.c2dm.intent.RECEIVE" />
             </intent-filter>
         </service>
         <service
-            android:name="gcm.MyInstanceIDListenerService"
+            android:name=".gcm.MyInstanceIDListenerService"
             android:exported="false">
             <intent-filter>
                 <action android:name="com.google.android.gms.iid.InstanceID"/>


### PR DESCRIPTION
MyInstanceIDListenerService and MyGcmListenerService are in com.example.android.sunshine.app.gcm package . The missing dot operator(.) causes error in recognising actual file paths. Placing the dot causes the android studio to look inside of com.example.android.sunshine.app package rather than outside of it.